### PR TITLE
Use node 6 for build

### DIFF
--- a/npm-build.Dockerfile
+++ b/npm-build.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:6
 
 COPY package.json /code/renga-ui/package.json
 COPY package-lock.json /code/renga-ui/package-lock.json


### PR DESCRIPTION
package-lock is for node:6, so make was broken