### PR TITLE
closes #139:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM node:alpine
 
 WORKDIR /app
 COPY . /app
-# We rename index.html so we can add the right source for the keyckoak apdaptor into the script tag
-# inside the entrypoint and rename it back to index.html. This will allow to change KEYCLOAK_URL without
-# rebuilding the image.
-RUN npm install --silent && mv public/index.html public/index-template.html
+RUN npm install --silent && \
+    npm install -g serve
+
 EXPOSE 3000
 ENTRYPOINT ["/bin/sh", "/app/docker-entrypoint.sh"]
-CMD ["/usr/local/bin/npm",  "start"]
+CMD ["/usr/local/bin/serve", "-s", "-p", "3000", "./build/"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,13 +23,13 @@ echo " GITLAB_URL=$GITLAB_URL"
 echo " RENGA_UI_URL=$RENGA_UI_URL"
 echo "==================================================="
 
-ESCAPED_KEYCLOAK_URL=$(echo $KEYCLOAK_URL | sed -e 's/\//\\\//g')
+# Optimized production build
+npm run-script build
 
 # Add the script tag which loads the keycloak js adapter from the keycloak server
-cat /app/public/index-template.html \
-  | sed "/<head>/s/.*/&<script src=\"$ESCAPED_KEYCLOAK_URL\/auth\/js\/keycloak.js\"><\/script>/" \
-  > /app/public/index.html
+ESCAPED_KEYCLOAK_URL=$(echo $KEYCLOAK_URL | sed -e 's/\//\\\//g')
+sed -i -e "s/<head>/<head><script src=\"$ESCAPED_KEYCLOAK_URL\/auth\/js\/keycloak.js\"><\/script>/" /app/build/index.html
 
-cat /app/public/index.html
+cat /app/build/index.html
 
 exec -- $@

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src/styles --include-path ./node_modules src/styles/ -o src/styles --watch --recursive",
     "start-js": "REACT_APP_UI_DEV_MODE=$UI_DEV_MODE REACT_APP_GITLAB_URL=$GITLAB_URL REACT_APP_RENGA_UI_URL=$RENGA_UI_URL REACT_APP_KEYCLOAK_URL=$KEYCLOAK_URL react-scripts start",
     "start": "npm-run-all -p watch-css start-js",
-    "build": "npm run build-css && react-scripts build",
+    "build": "npm run build-css && REACT_APP_UI_DEV_MODE=false REACT_APP_GITLAB_URL=$GITLAB_URL REACT_APP_RENGA_UI_URL=$RENGA_UI_URL REACT_APP_KEYCLOAK_URL=$KEYCLOAK_URL react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "node_modules/eslint/bin/eslint.js src/",

--- a/src/utils/ServiceWorker.js
+++ b/src/utils/ServiceWorker.js
@@ -45,6 +45,9 @@ export default function register() {
 
 function registerValidSW(swUrl) {
   navigator.serviceWorker
+  // Chrome dev tools break on uncaught exception thrown inside the Promise constructor
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=465666
+  // A bit annoying, but it will go away for proper deployments using https.
     .register(swUrl)
     .then(registration => {
       registration.onupdatefound = () => {


### PR DESCRIPTION
 - Serve static ui files from a node server instead of using the webpack dev server when ui is running inside a docker container.