### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6-alpine
 RUN apk add --no-cache gcc g++ make libffi-dev openssl-dev python3-dev build-base && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
-    pip3 install --upgrade pycrypto>=2.6.1 flask>=0.12.2 && \
+    pip3 install --upgrade pycryptodome==3.5.1 flask>=0.12.2 && \
     apk del --purge gcc g++ make libffi-dev openssl-dev python3-dev build-base && \
     rm -r /root/.cache
 COPY ./server/requirements.txt /app/


### PR DESCRIPTION
- python-JOSE 2.0 replaced the crypto library dependency